### PR TITLE
Add healthcheck script

### DIFF
--- a/backend/utils/healthcheck.js
+++ b/backend/utils/healthcheck.js
@@ -1,0 +1,29 @@
+const http = require('http');
+
+const port = process.env.PORT || 5000;
+const options = {
+  host: 'localhost',
+  port,
+  path: '/health',
+  timeout: 2000,
+};
+
+const req = http.get(options, (res) => {
+  if (res.statusCode === 200) {
+    process.exit(0);
+  } else {
+    console.error(`Healthcheck failed with status: ${res.statusCode}`);
+    process.exit(1);
+  }
+});
+
+req.on('error', (err) => {
+  console.error('Healthcheck error:', err.message);
+  process.exit(1);
+});
+
+req.on('timeout', () => {
+  console.error('Healthcheck timed out');
+  req.destroy();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a `backend/utils/healthcheck.js` script so the Docker `HEALTHCHECK` directive works

## Testing
- `npm test` *(fails: process.exit called during DB setup)*

------
https://chatgpt.com/codex/tasks/task_e_688a0a6864bc8324a45f0ba9982d771b