### PR TITLE
Implement security middleware

### DIFF
--- a/backend/middleware/security.js
+++ b/backend/middleware/security.js
@@ -1,0 +1,61 @@
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
+const compression = require('compression');
+
+/**
+ * Apply security-related middleware to the given Express app.
+ * @param {import('express').Application} app
+ */
+function applySecurity(app) {
+  // Helmet configuration tailored for development and production
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          styleSrc: [
+            "'self'",
+            "'unsafe-inline'",
+            'https://cdnjs.cloudflare.com',
+            'https://fonts.googleapis.com'
+          ],
+          scriptSrc: [
+            "'self'",
+            "'unsafe-inline'",
+            "'unsafe-eval'",
+            'https://cdn.socket.io',
+            'https://cdnjs.cloudflare.com'
+          ],
+          imgSrc: ["'self'", 'data:', 'https:', 'blob:'],
+          connectSrc: ["'self'", 'ws:', 'wss:', 'https:', 'http:'],
+          fontSrc: [
+            "'self'",
+            'https://cdnjs.cloudflare.com',
+            'https://fonts.gstatic.com'
+          ],
+          objectSrc: ["'none'"],
+          mediaSrc: ["'self'"],
+          manifestSrc: ["'self'"]
+        }
+      },
+      crossOriginEmbedderPolicy: false
+    })
+  );
+
+  // Enable response compression
+  app.use(compression());
+
+  // Basic rate limiting for API routes
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 100,
+    message: {
+      success: false,
+      message: 'Too many requests from this IP, please try again later.'
+    }
+  });
+
+  app.use('/api/', limiter);
+}
+
+module.exports = applySecurity;

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,9 +2,7 @@ const express = require('express');
 const http = require('http');
 const socketio = require('socket.io');
 const cors = require('cors');
-const helmet = require('helmet');
-const compression = require('compression');
-const rateLimit = require('express-rate-limit');
+const applySecurity = require('./middleware/security');
 const morgan = require('morgan');
 const dotenv = require('dotenv');
 const path = require('path');
@@ -16,36 +14,8 @@ connectDB();
 
 const app = express();
 
-// FIXED: Development-friendly Helmet configuration
-app.use(helmet({
-  contentSecurityPolicy: {
-    directives: {
-      defaultSrc: ["'self'"],
-      styleSrc: ["'self'", "'unsafe-inline'", "https://cdnjs.cloudflare.com", "https://fonts.googleapis.com"],
-      scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://cdn.socket.io", "https://cdnjs.cloudflare.com"],
-      imgSrc: ["'self'", "data:", "https:", "blob:"],
-      connectSrc: ["'self'", "ws:", "wss:", "https:", "http:"],
-      fontSrc: ["'self'", "https://cdnjs.cloudflare.com", "https://fonts.gstatic.com"],
-      objectSrc: ["'none'"],
-      mediaSrc: ["'self'"],
-      manifestSrc: ["'self'"],
-    },
-  },
-  crossOriginEmbedderPolicy: false,
-}));
-
-app.use(compression());
-
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 100,
-  message: {
-    success: false,
-    message: 'Too many requests from this IP, please try again later.'
-  }
-});
-
-app.use('/api/', limiter);
+// Apply security-related middleware such as Helmet and rate limiting
+applySecurity(app);
 app.use(cors({
   origin: process.env.CLIENT_URL || 'http://localhost:5000',
   credentials: true


### PR DESCRIPTION
## Summary
- add an express security middleware helper that applies Helmet, compression and rate limiting
- use the new helper in server setup

## Testing
- `npm test` *(fails: process.exit called)*

------
https://chatgpt.com/codex/tasks/task_e_688a0a5e26648324b5dd4fb15924bbd2